### PR TITLE
Fix defining BeatSaberDir with BSMT

### DIFF
--- a/BeatSaverVoting/BeatSaverVoting.csproj
+++ b/BeatSaverVoting/BeatSaverVoting.csproj
@@ -12,6 +12,9 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
+    <BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
+    <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Added some properties to get rid of "Project doesn't support the BeatSaberDir property" error when setting up BeatSaberDir with [BSMT](https://github.com/Zingabopp/BeatSaberModdingTools/wiki/Resolving-References): [SetBeatSaberDirCommand.cs](https://github.com/Zingabopp/BeatSaberModdingTools/blob/master/BeatSaberModdingTools/Commands/SetBeatSaberDirCommand.cs#L126)

Copied from default BSMT template. Example usages: [PlaylistManager](https://github.com/rithik-b/PlaylistManager/blob/master/PlaylistManager/PlaylistManager.csproj#L9), [SongBrowser](https://github.com/halsafar/BeatSaberSongBrowser/blob/master/SongBrowserPlugin/SongBrowser.csproj#L10).