### PR TITLE
Fix wrong positions of icons without SongBrowser, optimize

### DIFF
--- a/BeatSaverVoting/HarmonyPatches/LevelSelectionPatch.cs
+++ b/BeatSaverVoting/HarmonyPatches/LevelSelectionPatch.cs
@@ -37,11 +37,14 @@ namespace BeatSaverVoting.HarmonyPatches
                 }
             }
 
-            ____favoritesBadgeImage.rectTransform.sizeDelta = new Vector2(3.5f, 7);
-            var transform = ____favoritesBadgeImage.transform;
-            var position = transform.position;
-            position = new Vector3(-0.47f, position.y, position.z);
-            transform.position = position;
+            if (____favoritesBadgeImage.rectTransform.sizeDelta.x < 3.5f)
+            {
+                ____favoritesBadgeImage.rectTransform.sizeDelta = new Vector2(3.5f, 7);
+                var transform = ____favoritesBadgeImage.transform;
+                var position = transform.localPosition;
+                position = new Vector3(position.x + 1.0f, position.y, position.z);
+                transform.localPosition = position;
+            }
         }
     }
 }

--- a/BeatSaverVoting/Properties/AssemblyInfo.cs
+++ b/BeatSaverVoting/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.1.0")]
-[assembly: AssemblyFileVersion("2.3.1.0")]
+[assembly: AssemblyVersion("2.3.2.0")]
+[assembly: AssemblyFileVersion("2.3.2.0")]

--- a/BeatSaverVoting/manifest.json
+++ b/BeatSaverVoting/manifest.json
@@ -11,5 +11,5 @@
     "BS Utils": "^1.11.0",
     "SongCore": "^3.7.0"
   },
-  "version": "2.3.1"
+  "version": "2.3.2"
 }


### PR DESCRIPTION
Fixes this: https://cdn.discordapp.com/attachments/443146108420620318/885591418452709386/unknown.png

Forgot to test how the plugin works without SongBrowser initially and didn't catch wrong positioning in native game.

Now uses `localPosition` and changes size/position only once (simple size check since default sizeDelta.x is `< 3.5f`)
Tested on 1.17 and 1.17.1, with and without SongBrowser and BetterSongList.